### PR TITLE
feat: add overlay_dir and is_separate_deploy_repo outputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,6 +249,93 @@ jobs:
           [[ "${{ steps.test12.outputs.ref }}" == "feature/test-123" ]] || exit 1
           [[ "${{ steps.test12.outputs.path }}" == "platform/payments/service" ]] || exit 1
       
+      # Test 13: With environment - test overlay_dir output
+      - name: Test with environment (prod)
+        id: test13
+        uses: ./
+        with:
+          source: "self"
+          environment: "prod"
+
+      - name: Validate with environment
+        run: |
+          echo "Test 13: With environment"
+          echo "Repository: ${{ steps.test13.outputs.repository }}"
+          echo "Path: ${{ steps.test13.outputs.path }}"
+          echo "Overlay dir: ${{ steps.test13.outputs.overlay_dir }}"
+          echo "Is separate deploy repo: ${{ steps.test13.outputs.is_separate_deploy_repo }}"
+
+          [[ "${{ steps.test13.outputs.overlay_dir }}" == "deploy/overlays/prod" ]] || exit 1
+          [[ "${{ steps.test13.outputs.is_separate_deploy_repo }}" == "false" ]] || exit 1
+
+      # Test 14: With environment and path
+      - name: Test with environment and path
+        id: test14
+        uses: ./
+        with:
+          source: ":services/api"
+          environment: "staging"
+
+      - name: Validate with environment and path
+        run: |
+          echo "Test 14: With environment and path"
+          echo "Path: ${{ steps.test14.outputs.path }}"
+          echo "Overlay dir: ${{ steps.test14.outputs.overlay_dir }}"
+
+          [[ "${{ steps.test14.outputs.overlay_dir }}" == "services/api/deploy/overlays/staging" ]] || exit 1
+
+      # Test 15: Without environment - overlay_dir should be empty
+      - name: Test without environment
+        id: test15
+        uses: ./
+        with:
+          source: "self:services/api"
+
+      - name: Validate without environment
+        run: |
+          echo "Test 15: Without environment"
+          echo "Path: ${{ steps.test15.outputs.path }}"
+          echo "Overlay dir: '${{ steps.test15.outputs.overlay_dir }}'"
+
+          [[ -z "${{ steps.test15.outputs.overlay_dir }}" ]] || exit 1
+
+      # Test 16: External repo - is_separate_deploy_repo should be true
+      - name: Test external repo deploy flag
+        id: test16
+        uses: ./
+        with:
+          source: "Acme/configs"
+          environment: "dev"
+
+      - name: Validate external repo deploy flag
+        run: |
+          echo "Test 16: External repo deploy flag"
+          echo "Repository: ${{ steps.test16.outputs.repository }}"
+          echo "Is separate deploy repo: ${{ steps.test16.outputs.is_separate_deploy_repo }}"
+          echo "Overlay dir: ${{ steps.test16.outputs.overlay_dir }}"
+
+          [[ "${{ steps.test16.outputs.is_separate_deploy_repo }}" == "true" ]] || exit 1
+          [[ "${{ steps.test16.outputs.overlay_dir }}" == "deploy/overlays/dev" ]] || exit 1
+
+      # Test 17: External repo with path and environment
+      - name: Test external repo with path and environment
+        id: test17
+        uses: ./
+        with:
+          source: "Acme/configs@main:platform/services"
+          environment: "qa"
+
+      - name: Validate external repo with path and environment
+        run: |
+          echo "Test 17: External repo with path and environment"
+          echo "Repository: ${{ steps.test17.outputs.repository }}"
+          echo "Path: ${{ steps.test17.outputs.path }}"
+          echo "Overlay dir: ${{ steps.test17.outputs.overlay_dir }}"
+          echo "Is separate deploy repo: ${{ steps.test17.outputs.is_separate_deploy_repo }}"
+
+          [[ "${{ steps.test17.outputs.overlay_dir }}" == "platform/services/deploy/overlays/qa" ]] || exit 1
+          [[ "${{ steps.test17.outputs.is_separate_deploy_repo }}" == "true" ]] || exit 1
+
       - name: Summary
         run: |
           echo "✅ All tests passed!"
@@ -266,3 +353,8 @@ jobs:
           echo "- Full specification"
           echo "- Path cleanup"
           echo "- Complex paths and refs"
+          echo "- With environment (overlay_dir output)"
+          echo "- With environment and path"
+          echo "- Without environment (no overlay_dir)"
+          echo "- External repo (is_separate_deploy_repo true)"
+          echo "- External repo with path and environment"

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Parses a deployment source string into repository, ref, and path components for 
     echo "Service path: ${{ steps.config.outputs.path }}"
 ```
 
-## Input
+## Inputs
 
 | Input | Description | Required |
 |-------|-------------|----------|
 | `source` | Config source: `[<repo>][@<ref>][:<path>]` | ✅ |
+| `environment` | The deployment environment (e.g., dev, staging, prod) | ❌ |
 
 ## Outputs
 
@@ -36,6 +37,8 @@ Parses a deployment source string into repository, ref, and path components for 
 | `ref` | Parsed git ref (branch or tag) |
 | `path` | Parsed path to service/app deployment directory |
 | `is_self` | Whether this is the current repository |
+| `overlay_dir` | The full path to the overlay directory (only when environment is provided) |
+| `is_separate_deploy_repo` | Whether the deployment repo is different from the current repository |
 
 ## Source Format
 

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,9 @@ inputs:
       - repo: "self" for current repo, or "owner/repo" (defaults to "self")
       - @ref: branch/tag (defaults to current ref for self, default branch for others)
       - :path: path to service/app directory (defaults to ".")
-      
+
       The action expects deployment configs to be in <path>/deploy/overlays/<env>
-      
+
       Examples:
         ""                                    # self, current ref, path="."
         self                                  # self, current ref, path="."
@@ -27,6 +27,9 @@ inputs:
         Acme/deployments                      # external repo, default branch, path="."
         Acme/deployments@main:services/api    # external repo, main branch, path="services/api"
     required: true
+  environment:
+    description: 'The deployment environment (e.g., dev, staging, prod)'
+    required: false
 
 outputs:
   repository:
@@ -41,6 +44,12 @@ outputs:
   is_self:
     description: 'Whether this is the current repository (true/false)'
     value: ${{ steps.parse.outputs.is_self }}
+  overlay_dir:
+    description: 'The full path to the overlay directory for the environment (only set if environment input is provided)'
+    value: ${{ steps.parse.outputs.overlay_dir }}
+  is_separate_deploy_repo:
+    description: 'Whether the deployment repo is different from the current repository (true/false)'
+    value: ${{ steps.parse.outputs.is_separate_deploy_repo }}
 
 runs:
   using: 'composite'
@@ -113,10 +122,32 @@ runs:
         CONFIG_PATH="${CONFIG_PATH%/}"              # Remove trailing slash
         CONFIG_PATH=$(echo "$CONFIG_PATH" | sed 's|/\+|/|g')  # Remove duplicate slashes
         
+        # Calculate overlay directory if environment is provided
+        ENVIRONMENT="${{ inputs.environment }}"
+        if [ -n "$ENVIRONMENT" ]; then
+          if [ "$CONFIG_PATH" = "." ]; then
+            OVERLAY_DIR="deploy/overlays/$ENVIRONMENT"
+          else
+            OVERLAY_DIR="$CONFIG_PATH/deploy/overlays/$ENVIRONMENT"
+          fi
+          echo "overlay_dir=$OVERLAY_DIR" >> $GITHUB_OUTPUT
+        fi
+
+        # Determine if this is a separate deploy repo
+        IS_SEPARATE_DEPLOY_REPO="false"
+        if [ "$REPO" != "$CURRENT_REPO" ]; then
+          IS_SEPARATE_DEPLOY_REPO="true"
+        fi
+
         # Set outputs
         echo "repository=$REPO" >> $GITHUB_OUTPUT
         echo "ref=$REF" >> $GITHUB_OUTPUT
         echo "path=$CONFIG_PATH" >> $GITHUB_OUTPUT
         echo "is_self=$IS_SELF" >> $GITHUB_OUTPUT
-        
-        echo "::notice::Parsed: repo='$REPO', ref='${REF:-<default>}', path='$CONFIG_PATH'"
+        echo "is_separate_deploy_repo=$IS_SEPARATE_DEPLOY_REPO" >> $GITHUB_OUTPUT
+
+        if [ -n "$ENVIRONMENT" ]; then
+          echo "::notice::Parsed: repo='$REPO', ref='${REF:-<default>}', path='$CONFIG_PATH', overlay='$OVERLAY_DIR'"
+        else
+          echo "::notice::Parsed: repo='$REPO', ref='${REF:-<default>}', path='$CONFIG_PATH'"
+        fi


### PR DESCRIPTION
## Summary
- Added two new outputs to support deployment workflow requirements
- `overlay_dir`: Calculates the full overlay directory path when environment is provided
- `is_separate_deploy_repo`: Identifies when using an external deployment repository

## Changes
- Added optional `environment` input
- Added `overlay_dir` output (conditionally set based on environment input)
- Added `is_separate_deploy_repo` output 
- Updated README documentation
- Added comprehensive test coverage for new functionality

## Test Plan
- [x] Added tests for overlay_dir with environment input
- [x] Added tests for overlay_dir without environment (empty output)
- [x] Added tests for is_separate_deploy_repo with self repo (false)
- [x] Added tests for is_separate_deploy_repo with external repo (true)
- [x] Tests run automatically on PR