### PR TITLE
fix: support trailing colon in source patterns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -336,25 +336,38 @@ jobs:
           [[ "${{ steps.test17.outputs.overlay_dir }}" == "platform/services/deploy/overlays/qa" ]] || exit 1
           [[ "${{ steps.test17.outputs.is_separate_deploy_repo }}" == "true" ]] || exit 1
 
+      # Test 18: Full Git ref with trailing colon
+      - name: "Test @refs/heads/main:"
+        id: test18
+        uses: ./
+        with:
+          source: "@refs/heads/main:"
+
+      - name: "Validate @refs/heads/main:"
+        run: |
+          echo "Test 18: @refs/heads/main:"
+          echo "Ref: ${{ steps.test18.outputs.ref }}"
+          echo "Path: ${{ steps.test18.outputs.path }}"
+
+          [[ "${{ steps.test18.outputs.ref }}" == "refs/heads/main" ]] || exit 1
+          [[ "${{ steps.test18.outputs.path }}" == "." ]] || exit 1
+
+      # Test 19: External repo with ref and trailing colon
+      - name: "Test Acme/configs@v1.2.3:"
+        id: test19
+        uses: ./
+        with:
+          source: "Acme/configs@v1.2.3:"
+
+      - name: "Validate Acme/configs@v1.2.3:"
+        run: |
+          echo "Test 19: Acme/configs@v1.2.3:"
+          echo "Ref: ${{ steps.test19.outputs.ref }}"
+          echo "Path: ${{ steps.test19.outputs.path }}"
+
+          [[ "${{ steps.test19.outputs.ref }}" == "v1.2.3" ]] || exit 1
+          [[ "${{ steps.test19.outputs.path }}" == "." ]] || exit 1
+
       - name: Summary
         run: |
           echo "✅ All tests passed!"
-          echo ""
-          echo "Tested scenarios:"
-          echo "- Empty string (all defaults)"
-          echo "- Explicit self"
-          echo "- Ref only (@main)"
-          echo "- Path only (:services/api)"
-          echo "- Ref and path (@main:services/api)"
-          echo "- Repo and path (self:services/api)"
-          echo "- External repo"
-          echo "- External repo with tag"
-          echo "- External repo with path"
-          echo "- Full specification"
-          echo "- Path cleanup"
-          echo "- Complex paths and refs"
-          echo "- With environment (overlay_dir output)"
-          echo "- With environment and path"
-          echo "- Without environment (no overlay_dir)"
-          echo "- External repo (is_separate_deploy_repo true)"
-          echo "- External repo with path and environment"

--- a/action.yml
+++ b/action.yml
@@ -74,12 +74,12 @@ runs:
           REPO="self"
           REF=""
           CONFIG_PATH="${BASH_REMATCH[1]}"
-        elif [[ "$SOURCE" =~ ^@([^:]+)(:.+)?$ ]]; then
-          # Just ref and optional path (e.g., "@main" or "@main:services/api")
+        elif [[ "$SOURCE" =~ ^@([^:]+)(:.*)?$ ]]; then
+          # Just ref and optional path (e.g., "@main" or "@main:services/api" or "@main:")
           REPO="self"
           REF="${BASH_REMATCH[1]}"
           CONFIG_PATH="${BASH_REMATCH[2]#:}"  # Remove : prefix
-        elif [[ "$SOURCE" =~ ^([^@:]+)(@[^:]+)?(:.+)?$ ]]; then
+        elif [[ "$SOURCE" =~ ^([^@:]+)(@[^:]+)?(:.*)?$ ]]; then
           # Standard format with repo
           REPO="${BASH_REMATCH[1]}"
           REF="${BASH_REMATCH[2]#@}"   # Remove @ prefix


### PR DESCRIPTION
## Summary
- Fixed regex patterns to support trailing colons without paths (e.g., `@refs/heads/main:`, `Acme/configs@v1.2.3:`)
- Changed `(:.+)?` to `(:.*)?` in both `@ref` and `repo@ref` patterns to match empty strings after colon
- Added tests for `@refs/heads/main:` and `Acme/configs@v1.2.3:` patterns