### PR TITLE
rebrand: KoalaOps → Skyhook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,13 +337,13 @@ jobs:
           [[ "${{ steps.test17.outputs.is_separate_deploy_repo }}" == "true" ]] || exit 1
 
       # Test 18: Full Git ref with trailing colon
-      - name: "Test @refs/heads/main:"
+      - name: Test @refs/heads/main:
         id: test18
         uses: ./
         with:
           source: "@refs/heads/main:"
 
-      - name: "Validate @refs/heads/main:"
+      - name: Validate @refs/heads/main:
         run: |
           echo "Test 18: @refs/heads/main:"
           echo "Ref: ${{ steps.test18.outputs.ref }}"
@@ -353,13 +353,13 @@ jobs:
           [[ "${{ steps.test18.outputs.path }}" == "." ]] || exit 1
 
       # Test 19: External repo with ref and trailing colon
-      - name: "Test Acme/configs@v1.2.3:"
+      - name: Test Acme/configs@v1.2.3:
         id: test19
         uses: ./
         with:
           source: "Acme/configs@v1.2.3:"
 
-      - name: "Validate Acme/configs@v1.2.3:"
+      - name: Validate Acme/configs@v1.2.3:
         run: |
           echo "Test 19: Acme/configs@v1.2.3:"
           echo "Ref: ${{ steps.test19.outputs.ref }}"

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Parses a deployment source string into repository, ref, and path components for 
 ## Usage
 
 ```yaml
-- uses: KoalaOps/parse-deploy-config-source@v1
+- uses: skyhook-io/parse-deploy-config-source@v1
   id: config
   with:
-    source: "KoalaOps/k8s-configs@main:services/backend"
+    source: "skyhook-io/k8s-configs@main:services/backend"
 
 # The actual deployment configs are expected at:
 # <path>/deploy/overlays/<environment>/

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Parse Deploy Config Source'
 description: 'Parse deployment configuration source string into repo, ref, and path components'
-author: 'KoalaOps'
+author: 'Skyhook'
 
 branding:
   icon: 'git-branch'

--- a/test-parsing.sh
+++ b/test-parsing.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Test script for parse-deploy-config-source patterns
+
+test_pattern() {
+    local pattern="$1"
+    local expected="$2"
+
+    echo "Testing: '$pattern'"
+
+    # Simulate the parsing logic from action.yml
+    SOURCE="$pattern"
+
+    if [ -z "$SOURCE" ] || [ "$SOURCE" = ":" ] || [ "$SOURCE" = "@" ]; then
+        REPO="self"
+        REF=""
+        CONFIG_PATH=""
+    elif [[ "$SOURCE" =~ ^:(.+)$ ]]; then
+        REPO="self"
+        REF=""
+        CONFIG_PATH="${BASH_REMATCH[1]}"
+    elif [[ "$SOURCE" =~ ^@([^:]+)(:.*)?$ ]]; then
+        REPO="self"
+        REF="${BASH_REMATCH[1]}"
+        CONFIG_PATH="${BASH_REMATCH[2]#:}"
+    elif [[ "$SOURCE" =~ ^([^@:]+)(@[^:]+)?(:.*)?$ ]]; then
+        REPO="${BASH_REMATCH[1]}"
+        REF="${BASH_REMATCH[2]#@}"
+        CONFIG_PATH="${BASH_REMATCH[3]#:}"
+    else
+        echo "  ❌ FAILED: Invalid format"
+        return 1
+    fi
+
+    # Clean up empty path to be "."
+    if [ -z "$CONFIG_PATH" ]; then
+        CONFIG_PATH="."
+    fi
+
+    echo "  Parsed: repo='$REPO', ref='$REF', path='$CONFIG_PATH'"
+
+    if [ "$expected" = "SHOULD_PASS" ]; then
+        echo "  ✅ PASSED"
+    fi
+    echo
+}
+
+echo "=== Testing various patterns ==="
+echo
+
+# Original patterns that should work
+test_pattern "" "SHOULD_PASS"
+test_pattern "self" "SHOULD_PASS"
+test_pattern "@main" "SHOULD_PASS"
+test_pattern ":services/api" "SHOULD_PASS"
+test_pattern "@main:services/api" "SHOULD_PASS"
+test_pattern "self:services/api" "SHOULD_PASS"
+test_pattern "Acme/configs" "SHOULD_PASS"
+test_pattern "Acme/configs@v1.2.3" "SHOULD_PASS"
+test_pattern "Acme/configs:services/api" "SHOULD_PASS"
+test_pattern "Acme/configs@main:services/api" "SHOULD_PASS"
+
+# Edge cases with trailing colons (now should work)
+test_pattern "@main:" "SHOULD_PASS"
+test_pattern "@refs/heads/main:" "SHOULD_PASS"
+test_pattern "self:" "SHOULD_PASS"
+test_pattern "Acme/configs:" "SHOULD_PASS"
+test_pattern "Acme/configs@main:" "SHOULD_PASS"
+
+# Other edge cases
+test_pattern ":" "SHOULD_PASS"
+test_pattern "@" "SHOULD_PASS"
+test_pattern "@refs/heads/main" "SHOULD_PASS"
+test_pattern "@refs/tags/v1.0.0" "SHOULD_PASS"
+test_pattern "@refs/heads/feature/new-thing:services/api" "SHOULD_PASS"


### PR DESCRIPTION
## Summary
Update all references from KoalaOps to Skyhook as part of the rebranding initiative.

## Changes
- Organization: `KoalaOps` → `skyhook-io`
- Author: `KoalaOps` → `Skyhook`
- Product name: `Koala` → `Skyhook` (where applicable)
- All usage examples updated to reference `skyhook-io/*`
- All documentation and URLs updated

## Notes
- This PR should be merged before transferring the repository to the skyhook-io organization
- After transfer, GitHub will automatically redirect old URLs to new ones